### PR TITLE
workflows: use ${{ variable }} not invalid $${{

### DIFF
--- a/.github/workflows/sel4webserver-deploy.yml
+++ b/.github/workflows/sel4webserver-deploy.yml
@@ -76,7 +76,7 @@ jobs:
         uses: seL4/ci-actions/webserver-hw@master
         with:
           platform: ${{ matrix.platform }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
 


### PR DESCRIPTION
I'm not entirely sure how this worked... but I guess GitHub ignores the extra $ sign.